### PR TITLE
Remove unclutter-startup, if installed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ Vcs-Git: https://github.com/regolith-linux/regolith-desktop.git
 
 Package: regolith-desktop
 Architecture: any
-Depends: 
+Conflicts: unclutter-startup
+Depends:
     ${misc:Depends},
     gnome-control-center,
     gnome-flashback,
@@ -29,9 +30,9 @@ Depends:
     regolith-rofication | notification-daemon,
     regolith-styles,
     rofi,
-    unclutter-xfixes,    
+    unclutter-xfixes,
     xrescat
-Suggests: 
+Suggests:
     update-manager,
     software-properties-gtk
 Multi-Arch: foreign

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -Eeu -o pipefail
+
+apt purge -q=3 unclutter-startup


### PR DESCRIPTION
This completely removed `unclutter-startup`, which is conflicting with our handling of `unclutter-xfixes`. I'll also submit another PR against `unclutter-xfixes` to _not_ recommend `unclutter-startup` anymore.