### PR TITLE
Remove postinst to unblock upgrades

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -Eeu -o pipefail
-
-apt purge -q=3 unclutter-startup


### PR DESCRIPTION
You cannot execute `apt` or `dpkg` in `postinst` since the main process is blocking the package archive :see_no_evil: 

We'll have to let go of this.