### PR TITLE
Removed i3xrocks-next-workspace as a direct dependency, re-added xorg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Depends:
     i3-gaps-wm,
     i3-snapshot,
     i3xrocks,
-    i3xrocks-next-workspace,
     mutter-common,
     nautilus,
     regolith-compositor-picom-glx | regolith-compositor,
@@ -32,7 +31,8 @@ Depends:
     regolith-styles,
     regolith-unclutter-xfixes,
     rofi,
-    xrescat
+    xrescat,
+    xorg
 Provides: regolith-desktop-meta
 Conflicts: unclutter-startup, regolith-desktop-meta
 Replaces: regolith-desktop-meta
@@ -41,7 +41,7 @@ Suggests:
     software-properties-gtk
 Multi-Arch: foreign
 Description: metapackage for Regolith desktop environment
- This package contains all the packages necessary for the 
+ This package contains all the packages necessary for the
  desktop environment to function.
 
 Package: regolith-desktop-minimal


### PR DESCRIPTION
Removing `i3xrocks-next-workspace` as a direct dependency, because otherwise, if you don't want to use the applet, this is the result:
```
$ sudo apt remove --purge i3xrocks-next-workspace 
[...]
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  ayu-theme compton faba-icon-theme fonts-jetbrains-mono fonts-materialdesignicons-webfont gnome-system-tools gsettings-ubuntu-schemas i3-gaps-wm i3-snapshot libanyevent-i3-perl
  libanyevent-perl libasync-interrupt-perl libavahi-ui-gtk3-0 libcommon-sense-perl libconfig9 libev-perl libev4 libglu1-mesa libguard-perl libjson-xs-perl libjsoncpp1 libjsonrpc-glib-1.0-1
  libmetacity1 liboobs-1-5 libtypes-serialiser-perl libxcb-composite0 libxcb-cursor0 libxcb-damage0 libxcb-ewmh2 libxdg-basedir1 libxdo3 libyajl2 metacity metacity-common moka-icon-theme
  network-manager-config-connectivity-ubuntu python3-i3ipc python3-xlib regolith-compositor-compton-glx regolith-default-settings regolith-ftue regolith-gnome-flashback
  regolith-i3-gaps-config regolith-look-lascaille regolith-rofi-config regolith-styles regolith-unclutter-xfixes remontoire rofi system-tools-backends ubuntu-system-service x11-apps
  x11-session-utils xdotool xinit xorg
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  i3xrocks-next-workspace* regolith-desktop* regolith-system*
0 upgraded, 0 newly installed, 3 to remove and 0 not upgraded.
After this operation, 49,2 kB disk space will be freed.
Do you want to continue? [Y/n]
```
Obviously, we don't want to do that just to get rid of a single i3xrocks applet.

Also, adding back `xorg` as a direct dependency of `regolith-desktop` (previously was `regolith-system`), in line with all other Ubuntu derivatives:
```
$ apt rdepends xorg
xorg
Reverse Depends:
  Replaces: xdiagnose (<< 1:7.6+7ubuntu1)
  Depends: ubuntu-desktop-minimal
  Depends: ubuntu-desktop
  Depends: xubuntu-desktop
  Depends: xubuntu-core
  Recommends: xorgxrdp
  Recommends: xfce4
  Depends: ubuntu-desktop
  Depends: vanilla-gnome-desktop
  Depends: ubuntustudio-desktop-core
  Depends: ubuntustudio-desktop
  Depends: ubuntukylin-desktop
  Depends: ubuntu-unity-desktop
  Depends: ubuntu-mate-desktop
  Depends: ubuntu-mate-core
  Depends: ubuntu-budgie-desktop
  Depends: lubuntu-desktop
  Depends: kubuntu-desktop
  Suggests: kde-full
  Depends: ubuntu-desktop-minimal
```
Otherwise, this is the result:
```
The following packages were automatically installed and are no longer required:
  libglu1-mesa x11-apps x11-session-utils xorg
```